### PR TITLE
Add iox-roudi launch environment

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -1,0 +1,52 @@
+name: Create and publish a Docker image
+
+on:
+  push:
+    tags: ["*"]
+
+env:
+  REGISTRY: ghcr.io
+  IMAGE_NAME: ${{ github.repository }}
+  ROS_DISTRO: humble
+
+jobs:
+  build-and-push-image:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+
+    steps:
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Log in to the Container registry
+        uses: docker/login-action@v3
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Docker meta
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+          tags: |
+            type=ref,event=branch
+            type=semver,pattern={{version}}
+            type=semver,pattern={{major}}.{{minor}}
+
+      - name: Build and push Docker image
+        uses: docker/build-push-action@v5
+        with:
+          context: .
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          file: Dockerfile
+          target: runtime
+          

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -49,4 +49,3 @@ jobs:
           labels: ${{ steps.meta.outputs.labels }}
           file: Dockerfile
           target: runtime
-          

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,160 @@
+
+# To use:
+#
+#     pre-commit run -a
+#
+# Or:
+#
+#     pre-commit install  # (runs every time you commit in git)
+#
+# To update this file:
+#
+#     pre-commit autoupdate
+#
+# See https://github.com/pre-commit/pre-commit
+
+repos:
+  # Standard hooks
+  - repo: https://github.com/pre-commit/pre-commit-hooks
+    rev: v4.6.0
+    hooks:
+      - id: check-added-large-files
+      - id: check-ast
+      - id: check-case-conflict
+      - id: check-docstring-first
+      - id: check-merge-conflict
+      - id: check-symlinks
+      - id: check-xml
+      - id: check-yaml
+      - id: debug-statements
+      - id: end-of-file-fixer
+      - id: mixed-line-ending
+      - id: trailing-whitespace
+        exclude_types: [rst]
+      - id: fix-byte-order-marker
+
+  # Python hooks
+  - repo: https://github.com/asottile/pyupgrade
+    rev: v3.15.2
+    hooks:
+    -   id: pyupgrade
+        args: [--py36-plus]
+
+  - repo: https://github.com/psf/black
+    rev: 24.4.2
+    hooks:
+      - id: black
+        args: ["--line-length=79", -S]
+
+  # CPP hooks
+  - repo: https://github.com/pre-commit/mirrors-clang-format
+    rev: v18.1.4
+    hooks:
+      - id: clang-format
+        args: ['-fallback-style=none', '-i']
+
+  - repo: local
+    hooks:
+      - id: ament_cppcheck
+        name: ament_cppcheck
+        description: Static code analysis of C/C++ files.
+        entry: env AMENT_CPPCHECK_ALLOW_SLOW_VERSIONS=1 ament_cppcheck
+        language: system
+        files: \.(h\+\+|h|hh|hxx|hpp|cuh|c|cc|cpp|cu|c\+\+|cxx|tpp|txx)$
+
+  - repo: local
+    hooks:
+      - id: ament_cpplint
+        name: ament_cpplint
+        description: Static code analysis of C/C++ files.
+        entry: ament_cpplint
+        language: system
+        files: \.(h\+\+|h|hh|hxx|hpp|cuh|c|cc|cpp|cu|c\+\+|cxx|tpp|txx)$
+        args: ["--linelength=100", "--filter=-legal/copyright,-build/include_order"]
+
+  # Cmake hooks
+  - repo: local
+    hooks:
+      - id: ament_lint_cmake
+        name: ament_lint_cmake
+        description: Check format of CMakeLists.txt files.
+        entry: ament_lint_cmake
+        language: system
+        files: CMakeLists\.txt$
+
+  - repo: https://github.com/cheshirekow/cmake-format-precommit
+    rev: v0.6.13
+    hooks:
+      - id: cmake-format
+
+  # Docs - RestructuredText hooks
+  - repo: https://github.com/PyCQA/doc8
+    rev: v1.1.1
+    hooks:
+      - id: doc8
+        args: ['--max-line-length=100', '--ignore=D001']
+        exclude: CHANGELOG\.rst$
+
+  - repo: https://github.com/pre-commit/pygrep-hooks
+    rev: v1.10.0
+    hooks:
+      - id: rst-backticks
+        exclude: CHANGELOG\.rst$
+      - id: rst-directive-colons
+      - id: rst-inline-touching-normal
+
+  # Spellcheck in comments and docs
+  # skipping of *.svg files is not working...
+  - repo: https://github.com/codespell-project/codespell
+    rev: v2.2.6
+    hooks:
+      - id: codespell
+        args: ['--write-changes', '--uri-ignore-words-list=ist', '-L manuel']
+        exclude: CHANGELOG\.rst|\.(svg|pyc|drawio|dae)$
+
+  # Check Github files
+  - repo: https://github.com/python-jsonschema/check-jsonschema
+    rev: 0.28.2
+    hooks:
+      - id: check-github-workflows
+        args: ["--verbose"]
+      - id: check-github-actions
+        args: ["--verbose"]
+      - id: check-dependabot
+        args: ["--verbose"]
+
+  # Bash prettify
+  - repo: https://github.com/lovesegfault/beautysh
+    rev: v6.2.1
+    hooks:
+      - id: beautysh
+
+  # ROS checks
+  - repo: https://github.com/tier4/pre-commit-hooks-ros
+    rev: v0.8.0
+    hooks:
+      - id: flake8-ros
+      - id: prettier-xacro
+      - id: prettier-launch-xml
+      - id: prettier-package-xml
+      - id: ros-include-guard
+      - id: sort-package-xml
+
+  # Dockerfiles
+  - repo: https://github.com/AleksaC/hadolint-py
+    rev: v2.12.1b3
+    hooks:
+      - id: hadolint
+        args: ['--ignore=DL3008']
+
+ci:
+    autofix_commit_msg: |
+        [pre-commit.ci] auto fixes from pre-commit.com hooks
+
+        for more information, see https://pre-commit.ci
+    autofix_prs: false
+    autoupdate_branch: ''
+    autoupdate_commit_msg: '[pre-commit.ci] pre-commit autoupdate'
+    autoupdate_schedule: weekly
+    skip: [ament_cppcheck, ament_cpplint, ament_lint_cmake]
+    submodules: false

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,51 @@
+FROM ros:humble-ros-base-jammy AS base
+
+# Install key dependencies
+RUN apt-get update \
+    && DEBIAN_FRONTEND=noninteractive \
+    apt-get -y --quiet --no-install-recommends install \
+        ros-"$ROS_DISTRO"-rmw-cyclonedds-cpp \
+    && rm -rf /var/lib/apt/lists/*
+
+# Setup ROS workspace folder
+ENV ROS_WS /opt/ros_ws
+WORKDIR $ROS_WS
+
+# Set cyclone DDS ROS RMW
+ENV RMW_IMPLEMENTATION=rmw_cyclonedds_cpp
+
+COPY ./roudi_config.toml $ROS_WS/
+
+# Add tools to PATH
+RUN echo "source /opt/ros/$ROS_DISTRO/setup.bash" >> /root/.bashrc
+
+# -----------------------------------------------------------------------
+
+FROM base AS dev
+
+# Install basic dev tools (And clean apt cache afterwards)
+RUN apt-get update \
+    && DEBIAN_FRONTEND=noninteractive \
+    apt-get -y --quiet --no-install-recommends install \
+        # Command-line editor
+        nano \
+        # Ping network tools
+        inetutils-ping \
+        # Bash auto-completion for convenience
+        bash-completion \
+    && rm -rf /var/lib/apt/lists/*
+
+# Add colcon build alias for convenience
+RUN echo 'alias colcon_build="colcon build --symlink-install \
+    --cmake-args -DCMAKE_BUILD_TYPE=Release && \
+    source install/setup.bash"' >> /root/.bashrc
+
+# Enter bash for clvelopment
+CMD ["bash"]
+
+# -----------------------------------------------------------------------
+
+FROM base as runtime
+
+# Start recording a rosbag by default
+CMD ["iox-roudi", "-c", "/opt/ros_ws/roudi_config.toml"]

--- a/dev.sh
+++ b/dev.sh
@@ -9,13 +9,10 @@ DOCKER_BUILDKIT=1 docker build \
     -t av_iox_roudi_launch:latest-dev \
     -f Dockerfile --target dev .
 
-# Get the absolute path of the script
-SCRIPT_DIR=$(dirname "$(readlink -f "${BASH_SOURCE[0]}")")
-
 # Run docker image with local code volumes for development
 docker run -it --rm --net host --privileged \
     -v /dev:/dev \
     -v /tmp:/tmp \
-    -v $SCRIPT_DIR/roudi_config.toml:/opt/ros_ws/roudi_config.toml \
+    -v ./roudi_config.toml:/opt/ros_ws/roudi_config.toml \
     -v /etc/localtime:/etc/localtime:ro \
     av_iox_roudi_launch:latest-dev

--- a/dev.sh
+++ b/dev.sh
@@ -1,0 +1,21 @@
+#!/bin/bash
+# ----------------------------------------------------------------
+# Build docker dev stage and add local code for live development
+# ----------------------------------------------------------------
+
+
+# Build docker image up to dev stage
+DOCKER_BUILDKIT=1 docker build \
+    -t av_iox_roudi_launch:latest-dev \
+    -f Dockerfile --target dev .
+
+# Get the absolute path of the script
+SCRIPT_DIR=$(dirname "$(readlink -f "${BASH_SOURCE[0]}")")
+
+# Run docker image with local code volumes for development
+docker run -it --rm --net host --privileged \
+    -v /dev:/dev \
+    -v /tmp:/tmp \
+    -v $SCRIPT_DIR/roudi_config.toml:/opt/ros_ws/roudi_config.toml \
+    -v /etc/localtime:/etc/localtime:ro \
+    av_iox_roudi_launch:latest-dev

--- a/roudi_config.toml
+++ b/roudi_config.toml
@@ -1,0 +1,37 @@
+# Adapt this config to your needs and rename it to e.g. roudi_config.toml
+[general]
+version = 1
+
+[[segment]]
+
+[[segment.mempool]]
+size = 128
+count = 10000
+
+[[segment.mempool]]
+size = 1024
+count = 5000
+
+[[segment.mempool]]
+size = 16384
+count = 1000
+
+[[segment.mempool]]
+size = 131072
+count = 200
+
+[[segment.mempool]]
+size = 524288
+count = 50
+
+[[segment.mempool]]
+size = 1048576
+count = 30
+
+[[segment.mempool]]
+size = 4194304
+count = 30
+
+[[segment.mempool]]
+size = 13631488  # New mempool for 13 MB chunks (13 * 1024 * 1024 = 13631488)
+count = 20        # Adjust the count as needed

--- a/runtime.sh
+++ b/runtime.sh
@@ -1,0 +1,25 @@
+#!/bin/bash
+# ---------------------------------------------------------------------------
+# Build docker image and run ROS code for runtime or interactively with bash
+# ---------------------------------------------------------------------------
+
+# Initialise CMD as empty
+CMD=""
+
+# If an arg is defined, start container with bash
+if [ -n "$1" ]; then
+    CMD="bash"
+fi
+
+# Build docker image only up to base stage
+DOCKER_BUILDKIT=1 docker build \
+    -t av_iox_roudi_launch:latest \
+    -f Dockerfile --target runtime .
+
+
+# Run docker image
+docker run -it --rm --net host --privileged \
+    -v /dev:/dev \
+    -v /tmp:/tmp \
+    -v /etc/localtime:/etc/localtime:ro \
+    av_iox_roudi_launch:latest $CMD


### PR DESCRIPTION
- A dockerfile is provided to run iox-roudi with a custom `roudi_config.toml` cfg file
- `roudi_config.toml` is configured to allo msg transfer for up to 13 MiB. This is needed for dense lidar msgs
- `dev.sh` and `runtime.sh` are added
  - `runtime.sh` will build and run `runtime` build stage where  `iox-roudi` manager is run by default